### PR TITLE
Feature/ssd

### DIFF
--- a/CRA_TeamProject_SSD/CRA_TeamProject_SSD.vcxproj
+++ b/CRA_TeamProject_SSD/CRA_TeamProject_SSD.vcxproj
@@ -133,7 +133,8 @@
     <ClCompile Include="VirtualSSD.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="SSD.h" />
+    <ClInclude Include="ISSD.h" />
+    <ClInclude Include="VirtualSSD.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/CRA_TeamProject_SSD/CRA_TeamProject_SSD.vcxproj.filters
+++ b/CRA_TeamProject_SSD/CRA_TeamProject_SSD.vcxproj.filters
@@ -26,8 +26,11 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="SSD.h">
-      <Filter>소스 파일</Filter>
+    <ClInclude Include="ISSD.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="VirtualSSD.h">
+      <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/CRA_TeamProject_SSD/VirtualSSD.cpp
+++ b/CRA_TeamProject_SSD/VirtualSSD.cpp
@@ -1,21 +1,6 @@
-#include "ISSD.h"
-#include <string>
-#include <map>
+#include "VirtualSSD.h"
 
 using namespace std;
-
-class VirtualSSD : public ISSD
-{
-public:
-	void write(int lba, int data) override;
-	std::string read(int lba) override;
-	~VirtualSSD() {
-		// cache ->nand.txt
-	}
-
-private:
-	map<int, int> cache;
-};
 
 void VirtualSSD::write(int lba, int data)
 {

--- a/CRA_TeamProject_SSD/VirtualSSD.cpp
+++ b/CRA_TeamProject_SSD/VirtualSSD.cpp
@@ -11,3 +11,25 @@ std::string VirtualSSD::read(int lba)
 {
 	return std::string("temp");
 }
+
+VirtualSSD::~VirtualSSD()
+{
+	internalFlush();
+}
+
+void VirtualSSD::internalFlush()
+{
+	FILE* fp;
+	fopen_s(&fp, NAND_FILE_NAME, "w+");
+
+	if (fp == nullptr) {
+		throw exception_ptr();
+	}
+
+	for (map<int, int>::iterator it = cache.begin(); it != cache.end(); it++) {
+		string line = to_string((*it).first).append(",").append(to_string((*it).second));
+		fwrite(line.c_str(), sizeof(char), line.length(), fp);
+	}
+	fclose(fp);
+}
+

--- a/CRA_TeamProject_SSD/VirtualSSD.h
+++ b/CRA_TeamProject_SSD/VirtualSSD.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <string>
+#include <map>
+#include "ISSD.h"
+
+class VirtualSSD : public ISSD {
+public:
+	void write(int lba, int data) override;
+	std::string read(int lba) override;
+	~VirtualSSD();
+
+private:
+	const char* NAND_FILE_NAME = "nand.txt";
+	std::map<int, int> cache;
+	void internalFlush();
+};

--- a/Sample-Test1/Sample-Test1.vcxproj
+++ b/Sample-Test1/Sample-Test1.vcxproj
@@ -98,7 +98,10 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\packages\gmock.1.11.0\lib\native\src\gmock\src\gmock_main.cc" />
+    <ClCompile Include="..\packages\gmock.1.11.0\lib\native\src\gmock\src\gmock_main.cc">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="test.cpp" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
1. main에서 build error로 인해 VirtualSSD의 header를 분리하였습니다.
2. VirtualSSD 소멸 시 cache data를 nand.txt에 저장하도록 internal flush 구현하였습니다.