### PR TITLE
VirtualSSD 소멸자 두번 호출되면서 memory crash나는 bug fix

### DIFF
--- a/CRA_TeamProject_SSD/main.cpp
+++ b/CRA_TeamProject_SSD/main.cpp
@@ -15,8 +15,7 @@ void signalHandler(int signum) {
 
 int main()
 {
-    VirtualSSD ssd;
-    TestShell shell(&ssd);
+    TestShell shell(new VirtualSSD());
 
     globalShell = &shell;
     signal(SIGINT, signalHandler);


### PR DESCRIPTION
Test shell 소멸자에서 이미 소멸된 ssd 객체를 main 종료 시 지역변수를 소멸시키면서 두번 호출되어 shell 생성할 때 new로 넘겨주도록 수정하였습니다