### PR TITLE
test.cpp 버그 수정, printlog시 항상 checklog 파일 실행 되도록 변경

### DIFF
--- a/CRA_TeamProject_SSD/Logger.cpp
+++ b/CRA_TeamProject_SSD/Logger.cpp
@@ -6,11 +6,11 @@
 
 using namespace std;
 namespace fs = std::filesystem;
-
-
 	
 void Logger::printLog(string func, string msg)
 {
+	checkLogFile();
+
 	if (logfile.is_open() == false)
 	{
 		logfile.open(LATEST_LOG_NAME, ios::app);
@@ -27,6 +27,7 @@ void Logger::printLog(string func, string msg)
 	cout << log;
 	logfile << log;
 }
+
 void Logger::checkLogFile() {
 
 	if (LogFileSize(LATEST_LOG_NAME) < MAX_LOG_SIZE) return;

--- a/CRA_TeamProject_SSD/ShellCommand/FlushCommand.cpp
+++ b/CRA_TeamProject_SSD/ShellCommand/FlushCommand.cpp
@@ -2,7 +2,7 @@
 #include "ICommand.h"
 #include "../IApplication.h"
 #include "FlushCommand.h"
-#include "../TestApplication.cpp"
+#include "../Application/TestApplication.h"
 
 using namespace std;
 

--- a/Sample-Test1/test.cpp
+++ b/Sample-Test1/test.cpp
@@ -13,6 +13,7 @@
 #include "../CRA_TeamProject_SSD/ShellCommand/TestApp2Command.cpp"
 #include "../CRA_TeamProject_SSD/ShellCommand/EraseRangeCommand.cpp"
 #include "../CRA_TeamProject_SSD/ShellCommand/EraseSizeCommand.cpp"
+#include "../CRA_TeamProject_SSD/ShellCommand/FlushCommand.cpp"
 #include "../CRA_TeamProject_SSD/Application/ApplicationFactory.cpp"
 #include "../CRA_TeamProject_SSD/Application/TestApp1.cpp"
 #include "../CRA_TeamProject_SSD/Application/TestApplication.h"


### PR DESCRIPTION
test.cpp 버그 수정
printlog시 항상 checklog 파일 실행 되도록 변경