### PR TITLE
VirtualSSD의 cmd를 private로 감추고 getReadData로 data 받을 수 있도록 변경

### DIFF
--- a/CRA_TeamProject_SSD/ShellCommand/FullReadCommand.cpp
+++ b/CRA_TeamProject_SSD/ShellCommand/FullReadCommand.cpp
@@ -33,7 +33,7 @@ void FullReadCommand::sendFullReadSSDCmd() {
 			throw std::invalid_argument("sendFullReadSSDCmd Failed");
 		}
 		else {
-			string filename = "result.txt";
+			string filename = _ssd->getReadFileName();
 			std::ifstream file(filename);
 			if (!file) {
 				std::cerr << "Failed to open file: " << filename << std::endl;

--- a/CRA_TeamProject_SSD/ShellCommand/ReadCommand.cpp
+++ b/CRA_TeamProject_SSD/ShellCommand/ReadCommand.cpp
@@ -32,7 +32,7 @@ void ReadCommand::sendReadSSDCmd(int lba) {
 		throw std::invalid_argument("sendReadSSDCmd Failed");
 	}
 	else {
-		string filename = "result.txt";
+		string filename = _ssd->getReadFileName();
 		std::ifstream file(filename);
 		if (!file) {
 			PRINTLOG(filename + " OPEN FAIL!");

--- a/SSD/ISSD.h
+++ b/SSD/ISSD.h
@@ -26,6 +26,7 @@ public:
     virtual bool execute(SSDCommand command) = 0;
     const int getMinLBA() { return minLBA; }
     const int getMaxLBA() { return maxLBA; }
+    virtual const char* getReadFileName() = 0;
 
 protected:
     int minLBA;

--- a/SSD/VirtualSSD.cpp
+++ b/SSD/VirtualSSD.cpp
@@ -13,9 +13,9 @@ string VirtualSSD::read(int lba)
 			erase(command.param1, command.param3);
 		}
 	}
-	string retCacheValue = readCache(lba);
+	readData = readCache(lba);
 	cache = cache_backup;
-	return retCacheValue;
+	return readData;
 }
 
 bool VirtualSSD::execute(SSDCommand command)
@@ -28,6 +28,7 @@ bool VirtualSSD::execute(SSDCommand command)
 					return false;
 				}
 			}
+
 		}
 		else if (command.opcode == OPCODE::R) {
 			read(command.param1);
@@ -46,6 +47,16 @@ bool VirtualSSD::execute(SSDCommand command)
 	}
 
 	return true;
+}
+
+const char* VirtualSSD::getReadFileName()
+{
+	return RESULT_FILE_NAME;
+}
+
+std::string VirtualSSD::getReadData()
+{
+	return readData;
 }
 
 void VirtualSSD::write(int lba, string data)

--- a/SSD/VirtualSSD.h
+++ b/SSD/VirtualSSD.h
@@ -7,22 +7,25 @@
 
 class VirtualSSD : public ISSD {
 public:
-	const char* RESULT_FILE_NAME = "result.txt";
-
 	VirtualSSD();
 	~VirtualSSD() override;
-	void write(int lba, std::string data) override;
-	std::string read(int lba) override;
 	bool execute(SSDCommand command) override;
+	const char* getReadFileName() override;
+	std::string getReadData();
 
 private:
+	const char* RESULT_FILE_NAME = "result.txt";
 	const char* NAND_FILE_NAME = "nand.txt";
+	const char* BUFFER_FILE_NAME = "buffer.txt";
 	const char* INIT_VALUE = "0x00000000";
 	const int ERASE_MAXSIZE = 10;
 
 	std::map<int, std::string> cache;	
 	std::vector<SSDCommand> cmdBuffer;
+	std::string readData;
 
+	void write(int lba, std::string data) override;
+	std::string read(int lba) override;
 	bool erase(int lba, int size);
 	bool flush();
 

--- a/SSD/ssd_main.cpp
+++ b/SSD/ssd_main.cpp
@@ -11,7 +11,7 @@ void readTest(VirtualSSD& ssd, int lba) {
 	cmd.param1 = lba;
 	ssd.execute(cmd);
 
-	ifstream file(ssd.RESULT_FILE_NAME);
+	ifstream file(ssd.getReadFileName());
 	string ret;
 	file >> ret;
 	cout << "Result : " << ret << endl;

--- a/Sample-Test1/test.cpp
+++ b/Sample-Test1/test.cpp
@@ -37,6 +37,7 @@ public:
 	MOCK_METHOD(bool, execute, (SSDCommand command), (override));
 	MOCK_METHOD(bool, erase, (int lba, int size), (override));
 	MOCK_METHOD(bool, flush, (), (override));
+	MOCK_METHOD(const char*, getReadFileName, (), (override));
 };
 
 class MockTestShell : public TestShell {
@@ -72,6 +73,14 @@ class VirtualSSDTestFixture : public Test {
 public:
 	void SetUp() override {
 		testApp = new TestApplication(&virtualSSD);
+	}
+
+	SSDCommand generateReadCmd(int lba) {
+		return SSDCommand{ OPCODE::R, lba, "", 0 };
+	}
+
+	SSDCommand generateWriteCmd(int lba, string data) {
+		return SSDCommand{ OPCODE::W, lba, data, 0 };
 	}
 
 	TestApplication* testApp;
@@ -189,8 +198,10 @@ TEST_F(SSDTestFixture, ISSDTest_TestApp2Read_False) {
 TEST_F(VirtualSSDTestFixture, VirtualSSDTest_Compare)
 {
 	VirtualSSD virtualSSD;
-	virtualSSD.write(LBA_NORMAL, DATA_NORMAL);
-	EXPECT_EQ(virtualSSD.read(LBA_NORMAL), DATA_NORMAL);
+
+	EXPECT_EQ(virtualSSD.execute(generateWriteCmd(LBA_NORMAL, DATA_NORMAL)), true);
+	EXPECT_EQ(virtualSSD.execute(generateReadCmd(LBA_NORMAL)), true);
+	EXPECT_EQ(virtualSSD.getReadData(), DATA_NORMAL);
 }
 
 TEST_F(VirtualSSDTestFixture, VirtualSSDTest_TestApp1)


### PR DESCRIPTION
VirtualSSD의 cmd를 private로 감추고 getReadData로 data 받을 수 있도록 변경하고 result file name getter 구현하였습니다